### PR TITLE
shellsploit.py,  else forgotten...

### DIFF
--- a/shell/shellsploit.py
+++ b/shell/shellsploit.py
@@ -81,7 +81,7 @@ def shellsploit():
 						if terminal.split()[1] == shellcode:
 							B3mB4m().control(shellcode)
 							shellsploit()
-
+				else:
 					print ("\nModule not avaible !\n")
 					shellsploit()
 


### PR DESCRIPTION
terminal "use" function, 

```
...
	elif terminal[:3] == "use":
		all_sc_modules = []
		for platforms in shellcodeModules.keys():
			for shellcodeType in shellcodeModules[platforms]:
				all_sc_modules.append("{}/{}".format(platforms,shellcodeType))
				if terminal.split()[1] in all_sc_modules:
					for shellcode in all_sc_modules:
						if terminal.split()[1] == shellcode:
							B3mB4m().control(shellcode)
							shellsploit()

				
					print ("\nModule not avaible !\n")
					shellsploit()
...
```

"else" unused.. Not output "Module not avaible !". 


```
...
	elif terminal[:3] == "use":
		all_sc_modules = []
		for platforms in shellcodeModules.keys():
			for shellcodeType in shellcodeModules[platforms]:
				all_sc_modules.append("{}/{}".format(platforms,shellcodeType))
				if terminal.split()[1] in all_sc_modules:
					for shellcode in all_sc_modules:
						if terminal.split()[1] == shellcode:
							B3mB4m().control(shellcode)
							shellsploit()

				else:
					print ("\nModule not avaible !\n")
					shellsploit()
...
```

Fix!... 